### PR TITLE
Fixed update of convar values

### DIFF
--- a/lua/autorun/server/rocket_jumps.lua
+++ b/lua/autorun/server/rocket_jumps.lua
@@ -17,7 +17,7 @@ local function reduceRocketDamage( ent, dmginfo )
     local newForce = dmgForce * forceMult:GetFloat()
     dmginfo:SetDamageForce( newForce )
 
-    if ent:KeyDown( IN_DUCK	) then
+    if ent:KeyDown( IN_DUCK ) then
         ent:SetVelocity( newForce / 35 )
     else
         ent:SetVelocity( newForce / 70 )

--- a/lua/autorun/server/rocket_jumps.lua
+++ b/lua/autorun/server/rocket_jumps.lua
@@ -1,35 +1,20 @@
 -- Convars
-local enabled = CreateConVar( "rocketjumps_enabled", 1, { FCVAR_ARCHIVE }, "Enables rocket jumping (1/0).", 0 ):GetBool()
-cvars.AddChangeCallback( "rocketjumps_enabled", function( _, _, val )
-    enabled = tonumber( val )
-end)
-
-local scaleDamage = CreateConVar( "rocketjumps_dmgmult", 0.4, { FCVAR_ARCHIVE }, "The damage multiplier for self damaging explosions.", 0 ):GetFloat()
-cvars.AddChangeCallback( "rocketjumps_dmgmult", function( _, _, val )
-    scaleDamage = tonumber( val )
-end)
-
-local forceMult = CreateConVar( "rocketjumps_forcemult", 1, { FCVAR_ARCHIVE }, "The force multiplier for self damaging explosions.", 0 ):GetFloat()
-cvars.AddChangeCallback( "rocketjumps_forcemult", function( _, _, val )
-    forceMult = tonumber( val )
-end)
-
-local allExplosions = CreateConVar( "rocketjumps_allexplosions", 0, { FCVAR_ARCHIVE }, "Should the force multiplier be applied to all explosions instead of only self inflicted ones?.", 0 ):GetBool()
-cvars.AddChangeCallback( "rocketjumps_allexplosions", function( _, _, val )
-    allExplosions = tonumber( val )
-end)
+local enabled = CreateConVar( "rocketjumps_enabled", 1, { FCVAR_ARCHIVE }, "Enables rocket jumping (1/0).", 0 )
+local scaleDamage = CreateConVar( "rocketjumps_dmgmult", 0.4, { FCVAR_ARCHIVE }, "The damage multiplier for self damaging explosions.", 0 )
+local forceMult = CreateConVar( "rocketjumps_forcemult", 1, { FCVAR_ARCHIVE }, "The force multiplier for self damaging explosions.", 0 )
+local allExplosions = CreateConVar( "rocketjumps_allexplosions", 0, { FCVAR_ARCHIVE }, "Should the force multiplier be applied to all explosions instead of only self inflicted ones?.", 0 )
 
 local function reduceRocketDamage( ent, dmginfo )
-    if not enabled then return end
+    if not enabled:GetBool() then return end
     if not dmginfo:IsExplosionDamage() then return end
     if not ent:IsPlayer() then return end
 
     local attacker = dmginfo:GetAttacker()
 
-    if not allExplosions and attacker ~= ent then return end
+    if not allExplosions:GetBool() and attacker ~= ent then return end
 
     local dmgForce = dmginfo:GetDamageForce()
-    local newForce = dmgForce * forceMult
+    local newForce = dmgForce * forceMult:GetFloat()
     dmginfo:SetDamageForce( newForce )
 
     if ent:KeyDown( IN_DUCK	) then
@@ -38,7 +23,7 @@ local function reduceRocketDamage( ent, dmginfo )
         ent:SetVelocity( newForce / 70 )
     end
 
-    dmginfo:ScaleDamage( scaleDamage )
+    dmginfo:ScaleDamage( scaleDamage:GetFloat() )
 end
 
 hook.Add( "EntityTakeDamage", "rocketjumpsEntityTakeDamage", reduceRocketDamage )


### PR DESCRIPTION
Everything is in the title. Here are the steps to reproduce this issue on demand:

- Start a singleplayer game or on a dedicated server.
- Make sure the convar `rocketjumps_enabled` is set to **1** first.
- Take the rocket launcher in your hand and fire it near you to see that the script is working properly.
- Now set `rocketjumps_enabled` to **0**.
- Notice the script still works...

Here is also a proof by adding `print("passed")` to line 26: https://github.com/wrefgtzweve/easy-rocket-jumps/blob/e9a1e70b3c58dfe17113307431b34ee91f9590a0/lua/autorun/server/rocket_jumps.lua#L26

![image](https://user-images.githubusercontent.com/26360935/143685063-f7d01fe1-c41a-49bd-a846-8cdd771e3349.png)

I'll keep an eye out if you need additional information for this change. 👍 